### PR TITLE
Revert "Add prequal and update promo example"

### DIFF
--- a/affirm_example/__init__.py
+++ b/affirm_example/__init__.py
@@ -137,21 +137,6 @@ def shopping_item_page():
     }
 
 
-    # This data is used to initialize the Affirm Prequal
-    affirm_prequal_data = {
-        "page_type": "product",
-        "items": [
-             {
-                 "sku": "ACME-SLR-NG-01",
-                 "item_url": url_for(".shopping_item_page", **kwargs),
-                 "display_name": "Acme SLR-NG",
-                 "unit_price": 10000,
-                 "qty": 1
-             }
-         ],
-    }
-
-
     if app.config["INJECT_CHECKOUT_AMENDMENT_URL"]:
         affirm_checkout_data["merchant"]["checkout_amendment_url"] = url_for(
             ".affirm_checkout_amendment", **kwargs)
@@ -161,7 +146,6 @@ def shopping_item_page():
         kwargs.update({'_external': True, '_scheme': 'https'})
     template_data = dict(
         affirm_checkout=affirm_checkout_data,
-        affirm_prequal = affirm_prequal_data,
         item_image_url=url_for(".static", filename="item.png", **kwargs),
         display_name="Acme SLR-NG",
         unit_price_dollars="100.00",

--- a/affirm_example/manage.py
+++ b/affirm_example/manage.py
@@ -1,7 +1,7 @@
 import sys
 import os
 import os.path
-from flask_script import Server, Manager
+from flask.ext.script import Server, Manager
 from affirm_example import create_app
 import yaml
 

--- a/affirm_example/templates/index.html
+++ b/affirm_example/templates/index.html
@@ -28,7 +28,7 @@
     <style type="text/css" media="screen">
         body {
             margin: 1em;
-        }
+        } 
 
         .container {
             width: 372px;
@@ -69,9 +69,7 @@
                <img src="https://cdn1.affirm.com/images/badges/affirm-card_78x54.png" width="39" height="27"/>
                Pay with Affirm Split Pay
              </label>
-
-            <p id="ala" class="affirm-as-low-as" data-promo-id="promo_set_standard_gmat" data-amount="{{ (unit_price_dollars | float) * 100 }}"></p>
-
+             <div class="affirm-promo" data-promo-size="296x196" data-promo-content="https://www.affirm.com/images/png/press-green_mark.png"></div>
            </div>
            <!-- Checkout Submit Button -->
            <div class="col-xs-6 sidebar">
@@ -84,23 +82,6 @@
 
 
          <script type="application/javascript">
-           // Initialize prequal data & show prequal banner
-           let prequalData = {{ affirm_prequal | tojson | safe }};
-           affirm.ui.ready(function() {
-             affirm.prequal.set(prequalData);
-             affirm.ui.prequal.show();
-           });
-
-           // Update ALA promo when price changes
-           document.getElementById('item-price').addEventListener('input', function() {
-             console.log("here");
-             let newPrice = document.getElementById('item-price').value * 100;
-             document.getElementById('ala').setAttribute('data-amount', newPrice);
-             affirm.ui.refresh();
-           })
-
-
-           // Initialize and begin checkout
            var checkoutData = {{ affirm_checkout | tojson | safe }};
            function openCheckout(input) {
              var priceInput = document.getElementById("item-price");


### PR DESCRIPTION
Reverts Affirm/affirm-example-python#10

It turns out that the docker container with this image got deployed out to all our environments instead of just the one I specified. It broke FTs, so we are going to revert while we figure out why.