### PR TITLE
Add transactions endpoints for leases

### DIFF
--- a/affirm_example/config/app.yml.tmpl
+++ b/affirm_example/config/app.yml.tmpl
@@ -2,6 +2,8 @@ AFFIRM:
 
   API_URL: https://sandbox.affirm.com/api/v2
 
+  TRANSACTIONS_API_URL: https://sandbox.affirm.com/api/v1
+
   AFFIRM_JS_URL: https://cdn1-sandbox.affirm.com/js/v2/affirm.js
 
   # Set the public API key from Affirm

--- a/affirm_example/templates/lease_user_confirm.html
+++ b/affirm_example/templates/lease_user_confirm.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Lease User Confirm</title>
+</head>
+<body style="font-family: monospace">
+
+Affirm transaction ID: <b>{{ transaction_id }}</b>
+
+<br>
+<br>
+
+<div>
+    <table>
+        <tr>
+            <td>read</td>
+            <td><a href="{{ read_url }}" id="read" target="_blank">/api/v1/transactions/{{ transaction_id }}</a></td>
+        </tr>
+        <tr>
+            <td>capture</td>
+            <td><a href="{{ capture_url }}" id="capture" target="_blank">/api/v1/transactions/{{ transaction_id }}/capture</a></td>
+        </tr>
+        <tr>
+            <td>refund</td>
+            <td><a href="{{ refund_url }}" id="refund" target="_blank">/api/v1/transactions/{{ transaction_id }}/refund</a></td>
+        </tr>
+        <tr>
+            <td>void</td>
+            <td><a href="{{ void_url }}" id="void" target="_blank">/api/v1/transactions/{{ transaction_id }}/void</a></td>
+        </tr>
+    </table>
+    <br/>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
This PR adds a new user confirmation page for leases with links to transactions endpoints so that a user can easily test those actions.

JIRA ticket: CONNECT-359