### PR TITLE
Lock the pip version in Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN DEBIAN_FRONTEND=noninteractive \
                        python-virtualenv && \
     rm -rf /var/lib/apt/lists/* /tmp/* && \
     apt-get clean
-RUN pip install -U pip
+RUN pip install -U pip==19.2.3
 RUN pip install -U flask-script gevent gunicorn
 
 # copy code to /affirm


### PR DESCRIPTION
Pip is no longer supporting python2, so the latest versions will break builds if used. 

Here's an example...
```
 > [4/7] RUN pip install -U flask-script gevent gunicorn:
#8 0.378 Traceback (most recent call last):
#8 0.378   File "/usr/local/bin/pip", line 7, in <module>
#8 0.378     from pip._internal.cli.main import main
#8 0.378   File "/usr/local/lib/python2.7/dist-packages/pip/_internal/cli/main.py", line 60
#8 0.378     sys.stderr.write(f"ERROR: {exc}")
#8 0.378                                    ^
#8 0.378 SyntaxError: invalid syntax
```

Locking the pip version to `19.2.3` for now. We should consider upgrading this project to python3 if there are plans to continue development. 